### PR TITLE
Just remove added $captures from stack instead of copy whole snapshot

### DIFF
--- a/lib/Mojolicious/Routes/Match.pm
+++ b/lib/Mojolicious/Routes/Match.pm
@@ -84,10 +84,10 @@ sub _match {
   }
 
   # Match children
-  my $snapshot = $r->parent ? [@{$self->stack}] : [];
+  my $offset = $r->parent ? @{$self->stack} : 0;
   for my $child (@{$r->children}) {
     return 1 if $self->_match($child, $c, $options);
-    $self->stack([@$snapshot]);
+    splice @{$self->stack}, $offset;
   }
 }
 


### PR DESCRIPTION
### Summary
Because `_match` method is just add captures to the stack and do not change already matched  
We can just purge newly added captures to the stack when route is not matched

### Motivation
This is faster to purge added elements in compare to replace whole stack by snapshot

### References
related to [this commit](https://github.com/kraih/mojo/commit/ad14e43)
