### PR TITLE
Content negotiation v2

### DIFF
--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -91,6 +91,7 @@ sub build_controller {
   # Build default controller
   my $defaults = $self->defaults;
   @$stash{keys %$defaults} = values %$defaults;
+  delete $stash->{format};
   my $c
     = $self->controller_class->new(app => $self, stash => $stash, tx => $tx);
   Scalar::Util::weaken $c->{app};

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -91,7 +91,6 @@ sub build_controller {
   # Build default controller
   my $defaults = $self->defaults;
   @$stash{keys %$defaults} = values %$defaults;
-  delete $stash->{format};
   my $c
     = $self->controller_class->new(app => $self, stash => $stash, tx => $tx);
   Scalar::Util::weaken $c->{app};

--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -222,20 +222,15 @@ sub res { (shift->tx || Carp::croak 'Connection already closed')->res }
 sub respond_to {
   my ($self, $args) = (shift, ref $_[0] ? $_[0] : {@_});
 
+  # Detect format
+  my $renderer = $self->app->renderer;
+  my $format = $self->format( $renderer->default_format, keys %$args );
+  $self->stash->{format} = $format;
+
   # Find target
   my $target;
-  my $renderer = $self->app->renderer;
-  my @formats  = @{$renderer->accepts($self)};
-  for my $format (@formats ? @formats : ($renderer->default_format)) {
-    next unless $target = $args->{$format};
-    $self->stash->{format} = $format;
-    last;
-  }
-
-  # Fallback
-  unless ($target) {
+  unless ($target = $args->{$format}) {
     return $self->rendered(204) unless $target = $args->{any};
-    delete $self->stash->{format};
   }
 
   # Dispatch

--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -225,11 +225,10 @@ sub respond_to {
   # Detect format
   my $renderer = $self->app->renderer;
   my $format = $self->format( $renderer->default_format, keys %$args );
-  $self->stash->{format} = $format;
 
   # Find target
-  my $target;
-  unless ($target = $args->{$format}) {
+  my $target = $args->{$format};
+  unless( $target ) {
     return $self->rendered(204) unless $target = $args->{any};
   }
 

--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -22,6 +22,7 @@ sub register {
     $app->helper($name => sub { shift->stash($name, @_) });
   }
 
+  $app->helper(format  => sub { $_[0]->app->renderer->format(@_) });
   $app->helper(accepts => sub { $_[0]->app->renderer->accepts(@_) });
   $app->helper(b       => sub { shift; Mojo::ByteStream->new(@_) });
   $app->helper(c       => sub { shift; Mojo::Collection->new(@_) });
@@ -107,7 +108,7 @@ sub _development {
   my $renderer = $app->renderer;
   my $options  = {
     exception => $page eq 'exception' ? $e : undef,
-    format    => $stash->{format} || $renderer->default_format,
+    format    => scalar $c->format,
     handler   => undef,
     snapshot  => \%snapshot,
     status    => $page eq 'exception' ? 500 : 404,

--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -406,6 +406,28 @@ C<undef> if no helper or prefix could be found. Generated helpers return a
 proxy object containing the current controller object and on which nested
 helpers can be called.
 
+=head2 format
+
+  my $all  = $renderer->format(Mojolicious::Controller->new);
+  my $best = $renderer->format(Mojolicious::Controller->new, 'html', 'json');
+
+Select best possible representation for L<Mojolicious::Controller> object from
+C<format> stash value, C<format> C<GET>/C<POST> parameter, C<Accept> request
+header, supported C<format> for route or application. If no preference
+could be detected it will return one of next results:
+
+If C<format> is requested and route or application defines supported C<format>
+then empty string is returned
+
+If C<format> is requested and route or application does not define
+suported C<format>s then fallback to first requested C<format>
+
+If C<format> is not requested and route or application defines supported
+C<format> then fallback to first supported C<format>
+
+If C<format> is not requested and route or application does not define
+suported C<format>s fallback to renderer's default C<format>
+
 =head2 render
 
   my ($output, $format) = $renderer->render(Mojolicious::Controller->new, {

--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -60,7 +60,7 @@ sub format {
   # Find best representation
   for my $ext (@req) { $ext eq $_ and return $ext for @cap }
 
-  return @req ?
+  return $stash->{format} =  @req ?
     (@cap ? ''      : $req[0] ):
     (@cap ? $cap[0] : $self->default_format );
 }

--- a/lib/Mojolicious/Routes.pm
+++ b/lib/Mojolicious/Routes.pm
@@ -25,6 +25,9 @@ sub continue {
   my $position = $match->position;
   return _render($c) unless my $field = $stack->[$position];
 
+  # The format is negotiation process
+  delete $field->{format};
+
   # Merge captures into stash
   my $stash = $c->stash;
   @{$stash->{'mojo.captures'} //= {}}{keys %$field} = values %$field;

--- a/lib/Mojolicious/Routes.pm
+++ b/lib/Mojolicious/Routes.pm
@@ -74,6 +74,7 @@ sub match {
   $c->match($match);
   my $cache = $self->cache;
   if (my $result = $cache->get("$method:$path:$ws")) {
+    $match->{cn} =  $result->{cn};
     return $match->endpoint($result->{endpoint})->stack($result->{stack});
   }
 
@@ -81,7 +82,7 @@ sub match {
   $match->find($c => {method => $method, path => $path, websocket => $ws});
   return unless my $route = $match->endpoint;
   $cache->set(
-    "$method:$path:$ws" => {endpoint => $route, stack => $match->stack});
+    "$method:$path:$ws" => {endpoint => $route, stack => $match->stack, cn => $match->{cn}});
 }
 
 sub _action { shift->plugins->emit_chain(around_action => @_) }

--- a/lib/Mojolicious/Routes.pm
+++ b/lib/Mojolicious/Routes.pm
@@ -84,6 +84,8 @@ sub match {
   # Check routes
   $match->find($c => {method => $method, path => $path, websocket => $ws});
   return unless my $route = $match->endpoint;
+
+  $match->{cn}[1] //=  $c->app->defaults->{format};
   $cache->set(
     "$method:$path:$ws" => {endpoint => $route, stack => $match->stack, cn => $match->{cn}});
 }

--- a/lib/Mojolicious/Routes/Match.pm
+++ b/lib/Mojolicious/Routes/Match.pm
@@ -75,16 +75,7 @@ sub _match {
   # Endpoint (or intermediate destination)
   if (($endpoint && $empty) || $r->inline) {
     push @{$self->stack}, {%$captures};
-    if ($endpoint && $empty) {
-      my $format = $captures->{format};
-      if ($format) { $_->{format} = $format for @{$self->stack} }
-
-      $self->{cn} = exists $captures->{format} && !defined $captures->{format}?
-          [] : [ @$captures{qw/ _cformat _sformat /} ];
-      delete @$_{qw/ _cformat _sformat /} for @{$self->stack};
-
-      return !!$self->endpoint($r);
-    }
+    return !!$self->endpoint($r) if $endpoint && $empty;
     delete @$captures{qw(app cb)};
   }
 

--- a/lib/Mojolicious/Routes/Match.pm
+++ b/lib/Mojolicious/Routes/Match.pm
@@ -78,6 +78,11 @@ sub _match {
     if ($endpoint && $empty) {
       my $format = $captures->{format};
       if ($format) { $_->{format} = $format for @{$self->stack} }
+
+      $self->{cn} = exists $captures->{format} && !defined $captures->{format}?
+          [] : [ @$captures{qw/ _cformat _sformat /} ];
+      delete @$_{qw/ _cformat _sformat /} for @{$self->stack};
+
       return !!$self->endpoint($r);
     }
     delete @$captures{qw(app cb)};

--- a/lib/Mojolicious/Routes/Pattern.pm
+++ b/lib/Mojolicious/Routes/Pattern.pm
@@ -26,17 +26,12 @@ sub match_partial {
   $$pathref = ${^POSTMATCH};
   @captures = () if $#+ == 0;
   my $captures = {%{$self->defaults}};
-  for my $placeholder (@{$self->placeholders}) {
+  # default {format} will be checked while content negotiation. See accepts
+  delete $captures->{format};
+  for my $placeholder (@{$self->placeholders}, 'format') {
+    last unless @captures;
     my $capture = shift @captures;
     $captures->{$placeholder} = $capture if defined $capture;
-  }
-
-  if( defined $captures->{ format } ) {
-    $captures->{ _sformat } =  $captures->{ format };
-  }
-
-  if( defined( my $capture = shift @captures ) ) {
-    $captures->{ format } = $captures->{ _cformat } = $capture;
   }
 
   return $captures;
@@ -84,6 +79,7 @@ sub render {
   }
 
   # Format can be optional
+  $format //=  $self->defaults->{ format }   if !exists $values->{format};
   return $endpoint && $format ? "$str.$format" : $str;
 }
 

--- a/lib/Mojolicious/Routes/Pattern.pm
+++ b/lib/Mojolicious/Routes/Pattern.pm
@@ -26,10 +26,17 @@ sub match_partial {
   $$pathref = ${^POSTMATCH};
   @captures = () if $#+ == 0;
   my $captures = {%{$self->defaults}};
-  for my $placeholder (@{$self->placeholders}, 'format') {
-    last unless @captures;
+  for my $placeholder (@{$self->placeholders}) {
     my $capture = shift @captures;
     $captures->{$placeholder} = $capture if defined $capture;
+  }
+
+  if( defined $captures->{ format } ) {
+    $captures->{ _sformat } =  $captures->{ format };
+  }
+
+  if( defined( my $capture = shift @captures ) ) {
+    $captures->{ format } = $captures->{ _cformat } = $capture;
   }
 
   return $captures;

--- a/t/mojolicious/content_negotiation.t
+++ b/t/mojolicious/content_negotiation.t
@@ -1,0 +1,129 @@
+use Mojolicious::Lite;
+use Test::Mojo;
+use Test::More;
+
+app->routes->root->cache->max_keys(0);
+get '/app' => 'test';
+
+get '/route' => { template => 'test', format => 'xxx' };
+
+get '/detect_custom' => { template => 'test' } => sub{
+	shift->respond_to({
+		json => {},
+		zzz  => {},
+	});
+};
+
+get '/detect' => { template => 'test' } => sub{
+	shift->respond_to({
+		html => {},
+		json => {},
+		zzz  => {},
+	});
+};
+
+get '/detect_any' => { template => 'test' } => sub{
+	shift->respond_to({
+		html => {},
+		json => {},
+		zzz  => {},
+		any  => sub{ shift->render( text => 'any' ) },
+	});
+};
+
+get '/detect_custom_any' => { template => 'test' } => sub{
+	shift->respond_to({
+		json => {},
+		zzz  => {},
+		any  => sub{ shift->render( text => 'any' ) },
+	});
+};
+
+my $t = Test::Mojo->new;
+
+# Test detection of client requirements
+$t->get_ok('/app' => {Accept => 'application/json'} )->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')->content_is( "json\n" );
+$t->get_ok('/app.json'       )->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')->content_is( "json\n" );
+$t->get_ok('/app?format=json')->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')->content_is( "json\n" );
+
+
+# Test application default format
+$t->get_ok('/app'            )->status_is(200)
+  ->content_type_is('text/html;charset=UTF-8')       ->content_is( "html\n" );
+$t->get_ok('/app.zzz'        )->status_is(200)
+  ->content_type_is('text/plain')                    ->content_is( "zzz\n" );
+$t->get_ok('/app.not_exists' )->status_is(404);
+
+app->defaults( format => 'zzz' );
+$t->get_ok('/app'     )->status_is(200)
+  ->content_type_is('text/plain')                    ->content_is( "zzz\n" );
+$t->get_ok('/app.zzz' )->status_is(200)
+  ->content_type_is('text/plain')                    ->content_is( "zzz\n" );
+# Discuss: How to fallback when page not found?
+# $t->get_ok('/app.not_exists' )->status_is(404);
+
+
+#
+$t->get_ok('/route'     )->status_is(200)
+  ->content_type_is('text/plain')->content_is( "xxx\n" );
+$t->get_ok('/route.xxx' )->status_is(200)
+  ->content_type_is('text/plain')->content_is( "xxx\n" );
+# Discuss: How to fallback when page not found?
+# $t->get_ok('/route.json')->status_is(404)
+# $t->get_ok('/route.zzz' )->status_is(404)
+
+
+$t->get_ok('/detect_custom'     )->status_is(204)    ->content_is( '' );
+$t->get_ok('/detect_custom.xml' )->status_is(204)    ->content_is( '' );
+$t->get_ok('/detect_custom.zzz' )->status_is(200)
+  ->content_type_is('text/plain')                    ->content_is( "zzz\n" );
+$t->get_ok('/detect_custom.json')->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')->content_is( "json\n" );
+
+
+$t->get_ok('/detect'     )->status_is(200)
+  ->content_type_is('text/html;charset=UTF-8')       ->content_is( "html\n" );
+$t->get_ok('/detect.xml' )->status_is(204)           ->content_is( '' );
+$t->get_ok('/detect.zzz' )->status_is(200)
+  ->content_type_is('text/plain')                    ->content_is( "zzz\n" );
+$t->get_ok('/detect.json')->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')->content_is( "json\n" );
+
+
+$t->get_ok('/detect_any'     )->status_is(200)
+  ->content_type_is('text/html;charset=UTF-8')       ->content_is( "html\n" );
+$t->get_ok('/detect_any.xml' )->status_is(200)
+  ->content_type_is('text/html;charset=UTF-8')       ->content_is( 'any' );
+$t->get_ok('/detect_any.zzz' )->status_is(200)
+  ->content_type_is('text/plain')                    ->content_is( "zzz\n" );
+$t->get_ok('/detect_any.json')->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')->content_is( "json\n" );
+
+
+$t->get_ok('/detect_custom_any'     )->status_is(200)
+  ->content_type_is('text/html;charset=UTF-8')       ->content_is( 'any' );
+$t->get_ok('/detect_custom_any.xml' )->status_is(200)
+  ->content_type_is('text/html;charset=UTF-8')       ->content_is( 'any' );
+$t->get_ok('/detect_custom_any.zzz' )->status_is(200)
+  ->content_type_is('text/plain')                    ->content_is( "zzz\n" );
+$t->get_ok('/detect_custom_any.json')->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')->content_is( "json\n" );
+
+
+done_testing();
+
+__DATA__
+@@ test.html.ep
+html
+
+@@ test.zzz.ep
+zzz
+
+@@ test.xxx.ep
+xxx
+
+@@ test.json.ep
+json

--- a/t/mojolicious/exception_lite_app.t
+++ b/t/mojolicious/exception_lite_app.t
@@ -167,9 +167,8 @@ like $log, qr/dead template with layout!/, 'right result';
 
 # Dead action
 $t->get_ok('/dead_action')->status_is(500)
-  ->content_type_is('text/html;charset=UTF-8')
-  ->content_like(qr!get &#39;/dead_action&#39;!)
-  ->content_like(qr/dead action!/)->text_is('#error' => "dead action!\n");
+  ->content_type_is('text/plain;charset=UTF-8')
+  ->content_is("dead action!\n");
 like $log, qr/dead action!/, 'right result';
 
 # Dead action with different format
@@ -188,7 +187,7 @@ $t->get_ok('/dead_action' => {Accept => 'text/plain'})->status_is(500)
 
 # Action dies twice
 $t->get_ok('/double_dead_action_☃')->status_is(500)
-  ->content_like(qr!get &#39;/double_dead_action_☃&#39;.*lite_app\.t:\d!s)
+  ->content_type_is('text/plain;charset=UTF-8')
   ->content_like(qr/double dead action!/);
 
 # Trapped exception
@@ -230,8 +229,8 @@ $t->get_ok('/missing_template/too')->status_is(404)
 
 # Missing helper (correct context)
 $t->get_ok('/missing_helper')->status_is(500)
-  ->content_type_is('text/html;charset=UTF-8')->content_like(qr/Server error/)
-  ->content_like(qr/shift-&gt;missing_helper/);
+  ->content_type_is('text/plain;charset=UTF-8')
+  ->content_like(qr/missing_helper/);
 
 # Reuse exception
 ok !$exception, 'no exception';

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -110,7 +110,7 @@ get '/auto_name' => sub {
 
 get '/query_string' => sub {
   my $c = shift;
-  $c->render(text => $c->req->url->query);
+  $c->render(text => $c->req->url->query->to_string);
 };
 
 get '/reserved' => sub {

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -85,12 +85,12 @@ get '/optional/:param' =>
 
 get '/alterformat' => [format => ['json']] => {format => 'json'} => sub {
   my $c = shift;
-  $c->render(text => $c->stash('format'));
+  $c->render(text => $c->format);
 };
 
 get '/noformat' => [format => 0] => {format => 'xml'} => sub {
   my $c = shift;
-  $c->render(text => $c->stash('format') . $c->url_for);
+  $c->render(text => $c->format . $c->url_for);
 };
 
 del sub { shift->render(text => 'Hello!') };

--- a/t/mojolicious/pattern.t
+++ b/t/mojolicious/pattern.t
@@ -150,7 +150,7 @@ $pattern = Mojolicious::Routes::Pattern->new('/test');
 $pattern->defaults({action => 'index'});
 ok !$pattern->regex, 'no regex';
 is_deeply $pattern->match('/test.xml', 1),
-  {action => 'index', format => 'xml'}, 'right structure';
+  {action => 'index', format => 'xml', _cformat => 'xml'}, 'right structure';
 ok $pattern->regex, 'regex has been compiled on demand';
 $pattern = Mojolicious::Routes::Pattern->new('/test.json');
 $pattern->defaults({action => 'index'});
@@ -189,15 +189,16 @@ ok !$pattern->match('/.xml', 1), 'no result';
 $pattern = Mojolicious::Routes::Pattern->new('/:test/v1.0');
 $pattern->defaults({action => 'index', format => 'html'});
 my $result = $pattern->match('/foo/v1.0', 1);
-is_deeply $result, {test => 'foo', action => 'index', format => 'html'},
+is_deeply $result, {test => 'foo', action => 'index', format => 'html', _sformat => 'html'},
   'right structure';
 is $pattern->render($result), '/foo/v1.0', 'right result';
 is $pattern->render($result, 1), '/foo/v1.0.html', 'right result';
 is $pattern->render({%$result, format => undef}, 1), '/foo/v1.0',
   'right result';
 $result = $pattern->match('/foo/v1.0.txt', 1);
-is_deeply $result, {test => 'foo', action => 'index', format => 'txt'},
-  'right structure';
+my $capture = {test => 'foo', action => 'index', format => 'txt',
+  _sformat => 'html', _cformat => 'txt'};
+is_deeply $result, $capture, 'right structure';
 is $pattern->render($result), '/foo/v1.0', 'right result';
 is $pattern->render($result, 1), '/foo/v1.0.txt', 'right result';
 ok !$pattern->match('/foo/v2.0', 1), 'no result';
@@ -255,7 +256,7 @@ $pattern                        = Mojolicious::Routes::Pattern->new('/');
 $pattern->defaults->{format}    = 'txt';
 $pattern->constraints->{format} = ['txt'];
 $result                         = $pattern->match('/', 1);
-is_deeply $result, {format => 'txt'}, 'right structure';
+is_deeply $result, {format => 'txt', _sformat => 'txt'}, 'right structure';
 
 # Unicode
 $pattern = Mojolicious::Routes::Pattern->new('/(one)♥(two)');

--- a/t/mojolicious/pattern.t
+++ b/t/mojolicious/pattern.t
@@ -150,7 +150,7 @@ $pattern = Mojolicious::Routes::Pattern->new('/test');
 $pattern->defaults({action => 'index'});
 ok !$pattern->regex, 'no regex';
 is_deeply $pattern->match('/test.xml', 1),
-  {action => 'index', format => 'xml', _cformat => 'xml'}, 'right structure';
+  {action => 'index', format => 'xml'}, 'right structure';
 ok $pattern->regex, 'regex has been compiled on demand';
 $pattern = Mojolicious::Routes::Pattern->new('/test.json');
 $pattern->defaults({action => 'index'});
@@ -189,16 +189,15 @@ ok !$pattern->match('/.xml', 1), 'no result';
 $pattern = Mojolicious::Routes::Pattern->new('/:test/v1.0');
 $pattern->defaults({action => 'index', format => 'html'});
 my $result = $pattern->match('/foo/v1.0', 1);
-is_deeply $result, {test => 'foo', action => 'index', format => 'html', _sformat => 'html'},
+is_deeply $result, {test => 'foo', action => 'index'},
   'right structure';
 is $pattern->render($result), '/foo/v1.0', 'right result';
 is $pattern->render($result, 1), '/foo/v1.0.html', 'right result';
 is $pattern->render({%$result, format => undef}, 1), '/foo/v1.0',
   'right result';
 $result = $pattern->match('/foo/v1.0.txt', 1);
-my $capture = {test => 'foo', action => 'index', format => 'txt',
-  _sformat => 'html', _cformat => 'txt'};
-is_deeply $result, $capture, 'right structure';
+is_deeply $result, {test => 'foo', action => 'index', format => 'txt'},
+  'right structure';
 is $pattern->render($result), '/foo/v1.0', 'right result';
 is $pattern->render($result, 1), '/foo/v1.0.txt', 'right result';
 ok !$pattern->match('/foo/v2.0', 1), 'no result';
@@ -256,7 +255,7 @@ $pattern                        = Mojolicious::Routes::Pattern->new('/');
 $pattern->defaults->{format}    = 'txt';
 $pattern->constraints->{format} = ['txt'];
 $result                         = $pattern->match('/', 1);
-is_deeply $result, {format => 'txt', _sformat => 'txt'}, 'right structure';
+is_deeply $result, {}, 'right structure';
 
 # Unicode
 $pattern = Mojolicious::Routes::Pattern->new('/(one)♥(two)');

--- a/t/mojolicious/renderer.t
+++ b/t/mojolicious/renderer.t
@@ -9,6 +9,7 @@ my $app = Mojolicious->new(secrets => ['works']);
 my $c = $app->build_controller;
 $c->app->log->level('fatal');
 is $c->render_to_string(text => 'works'), 'works', 'renderer is working';
+delete $c->stash->{format}; # Reset stash after test
 
 # Normal rendering with default format
 my $renderer = $c->app->renderer->default_format('test');

--- a/t/mojolicious/routes.t
+++ b/t/mojolicious/routes.t
@@ -405,8 +405,8 @@ is $m->path_for->{path}, '/optional2/three/four', 'right path';
 $m = Mojolicious::Routes::Match->new(root => $r);
 $m->find($c => {method => 'GET', path => '/articles/1/edit'});
 my @stack = (
-  {controller => 'articles', action => 'load', id => 1, format => 'html'},
-  {controller => 'articles', action => 'edit', id => 1, format => 'html'}
+  {controller => 'articles', action => 'load', id => 1},
+  {controller => 'articles', action => 'edit', id => 1}
 );
 is_deeply $m->stack, \@stack, 'right structure';
 is $m->path_for->{path}, '/articles/1/edit', 'right path';
@@ -420,15 +420,15 @@ is $m->path_for('articles_delete', id => 12)->{path}, '/articles/12/delete',
 $m = Mojolicious::Routes::Match->new(root => $r);
 $m->find($c => {method => 'GET', path => '/articles/1/delete'});
 @stack = (
-  {controller => 'articles', action => 'load',   id => 1, format => 'html'},
-  {controller => 'articles', action => 'delete', id => 1, format => undef}
+  {controller => 'articles', action => 'load',   id => 1},
+  {controller => 'articles', action => 'delete', id => 1}
 );
 is_deeply $m->stack, \@stack, 'right structure';
 is $m->path_for->{path}, '/articles/1/delete', 'right path';
 $m = Mojolicious::Routes::Match->new(root => $r);
 $m->find($c => {method => 'GET', path => '/articles/1/delete.json'});
 @stack = (
-  {controller => 'articles', action => 'load',   id => 1, format => 'json'},
+  {controller => 'articles', action => 'load',   id => 1},
   {controller => 'articles', action => 'delete', id => 1, format => 'json'}
 );
 is_deeply $m->stack, \@stack, 'right structure';
@@ -552,8 +552,7 @@ is $m->path_for->{path}, '/wildcards/1/%foo%bar%', 'right path';
 $m = Mojolicious::Routes::Match->new(root => $r);
 $m->find($c => {method => 'GET', path => '/format'});
 is_deeply $m->stack,
-  [{controller => 'hello', action => 'you', format => 'html'}],
-  'right structure';
+  [{controller => 'hello', action => 'you'}], 'right structure';
 is $m->path_for->{path}, '/format', 'right path';
 is $m->path_for(format => undef)->{path},  '/format',      'right path';
 is $m->path_for(format => 'html')->{path}, '/format.html', 'right path';
@@ -612,7 +611,7 @@ is_deeply $m->stack, [], 'empty stack';
 # Format with constraint and default
 $m = Mojolicious::Routes::Match->new(root => $r);
 $m->find($c => {method => 'GET', path => '/format4'});
-is_deeply $m->stack, [{controller => 'us', action => 'yay', format => 'html'}],
+is_deeply $m->stack, [{controller => 'us', action => 'yay'}],
   'right structure';
 is $m->path_for->{path}, '/format4.html', 'right path';
 $m = Mojolicious::Routes::Match->new(root => $r);
@@ -639,7 +638,7 @@ is_deeply $m->stack, [], 'empty stack';
 # Forbidden format and default
 $m = Mojolicious::Routes::Match->new(root => $r);
 $m->find($c => {method => 'GET', path => '/format6'});
-is_deeply $m->stack, [{controller => 'us', action => 'doh', format => 'xml'}],
+is_deeply $m->stack, [{controller => 'us', action => 'doh'}],
   'right structure';
 is $m->path_for->{path}, '/format6', 'right path';
 $m = Mojolicious::Routes::Match->new(root => $r);
@@ -786,7 +785,7 @@ is_deeply $m->stack, [], 'empty stack';
 $m = Mojolicious::Routes::Match->new(root => $r);
 $m->find($c => {method => 'GET', path => '/multi/bar.baz'});
 is_deeply $m->stack,
-  [{controller => 'works', action => 'too', format => 'xml'}],
+  [{controller => 'works', action => 'too'}],
   'right structure';
 is $m->path_for->{path}, '/multi/bar.baz', 'right path';
 


### PR DESCRIPTION
In continue of [this](https://gist.github.com/KES777/0eec79515ef1c2c5c200ca902c9915ec)

jberger understands me right:

>once you've arrived at the resource you want, the representation is determined by content negotiation this is explicitly after routing is complete

As we both were agree yesterday: route matching is not content negotiation.  
Therefore `$c->stash->{format}` after route matching should be empty.  
(otherwise other code will think that content negotiation is done). Because of this I just do not merge `{format}` into stash:

[lib/Mojolicious/Routes/Pattern.pm](https://github.com/KES777/mojo/pull/40/files#diff-2650135fc08c671d8b875d9b8480f498)
```diff
@@ -26,6 +26,8 @@ sub match_partial {
   $$pathref = ${^POSTMATCH};
   @captures = () if $#+ == 0;
   my $captures = {%{$self->defaults}};
+  # default {format} will be checked while content negotiation. See accepts
+  delete $captures->{format};
   for my $placeholder (@{$self->placeholders}, 'format') {
     last unless @captures;
     my $capture = shift @captures;
```
[lib/Mojolicious/Routes.pm](https://github.com/KES777/mojo/pull/40/files#diff-6e5e5efb5e0e6c3cb4157384b8472135)
```diff
@@ -30,6 +30,9 @@ sub continue {
   @{$stash->{'mojo.captures'} //= {}}{keys %$field} = values %$field;
   @$stash{keys %$field} = values %$field;
 
+  # The {format} is negotiation process
+  delete $stash->{format};
+
   my $continue;
   my $last = !$stack->[++$position];
   if (my $cb = $field->{cb}) { $continue = $self->_callback($c, $cb, $last) }
```
Also I remove [this code](https://github.com/KES777/mojo/pull/40/files#diff-5b6455c74022510e3fb70258b87234ee) which was added by [commit#300485b22](https://github.com/kraih/mojo/commit/300485b222166):

```diff
@@ -75,11 +75,7 @@ sub _match {
   # Endpoint (or intermediate destination)
   if (($endpoint && $empty) || $r->inline) {
     push @{$self->stack}, {%$captures};
-    if ($endpoint && $empty) {
-      my $format = $captures->{format};
-      if ($format) { $_->{format} = $format for @{$self->stack} }
-      return !!$self->endpoint($r);
-    }
+    return !!$self->endpoint($r) if $endpoint && $empty;
     delete @$captures{qw(app cb)};
   }
```

Instead of this I have added content negotiation (which sets up `$c->stash->{format}`) [here](https://github.com/KES777/mojo/pull/40/files#diff-fc5e1c91161f82eb6d5f8cfe15a8aba1R108) and [here](https://github.com/KES777/mojo/pull/40/files#diff-ccf996555125c90064b288a0e4c139c5R128) so bridges / under routes can see `$c->stash->{format}` too:

```diff
lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -107,7 +108,7 @@ sub _development {
   my $renderer = $app->renderer;
   my $options  = {
     exception => $page eq 'exception' ? $e : undef,
-    format    => $stash->{format} || $renderer->default_format,
+    format    => scalar $c->format,
     handler   => undef,
     snapshot  => \%snapshot,
     status    => $page eq 'exception' ? 500 : 404,
```
```diff
https://github.com/KES777/mojo/pull/40/files#diff-ccf996555125c90064b288a0e4c139c5
@@ -93,7 +128,7 @@ sub render {
   };
   my $inline = $options->{inline} = delete $stash->{inline};
   $options->{handler} //= $self->default_handler if defined $inline;
-  $options->{format} = $stash->{format} || $self->default_format;
+  $options->{format} = $self->format( $c ) || $self->default_format;
 
   # Data
   return delete $stash->{data}, $options->{format} if defined $stash->{data};
@@ -115,7 +150,7 @@ sub render {
     if $stash->{extends} || $stash->{layout};
   while ((my $next = _next($stash)) && !defined $inline) {
     @$options{qw(handler template)} = ($stash->{handler}, $next);
-    $options->{format} = $stash->{format} || $self->default_format;
+    $options->{format} = $self->format( $c ) || $self->default_format;
     if ($self->_render_template($c, \my $tmp, $options)) { $output = $tmp }
     $content->{content} //= $output if $output =~ /\S/;
   }
```

NOTICE: It would be better to do content negotiation at `around_action` hook  but, unfortunately, default template rendering for actionless controller do not emit `around_action` hook.  

After these few changes bridges/under routes can see detected `format` and access it as before `$c->stash->{format}`

After that we can fix [`accepts`](https://github.com/KES777/mojo/pull/40/files#diff-ccf996555125c90064b288a0e4c139c5). Now it uses captured `format` instead of "half" negotiated `format` by route matching
```diff
@@ -27,7 +27,8 @@ sub accepts {
 
   # List representations
   my $req  = $c->req;
-  my $fmt  = $req->param('format') || $c->stash->{format};
+  my $capture =  $c->match->stack->[-1] || {};
+  my $fmt  = $req->param('format') || $capture->{format};
   my @exts = $fmt ? ($fmt) : ();
   push @exts, @{$c->app->types->detect($req->headers->accept)};
   return \@exts unless @_;
@@ -37,6 +38,40 @@ sub accepts {
   return @exts ? undef : shift;
 }
```

II. Downside of `accepts` helper method is that it returns list of requested `format` by user (It really stands for its purpose). Because of that `accepts` is not usable for content negotiation which should return `format`. So I implement additional helper with the same name [`format`](https://github.com/KES777/mojo/pull/40/files#diff-ccf996555125c90064b288a0e4c139c5R54) which _allow better fallbacks for content negotiation when html is not the default_.

```
  # /custom                      -> "json"
  # /custom.html                 -> undef
  # /custom.xml                  -> "xml"
  # /custom.txt                  -> undef
  $r->get( '/custom', { format => [qw( json, xml )] );
```

Also with this helper [`respond_to`](https://github.com/KES777/mojo/pull/40/files#diff-2fddbd3ca1b4987ef6bf8adc89ce2fd7) became more clear:
```perl
sub respond_to {
  my ($self, $args) = (shift, ref $_[0] ? $_[0] : {@_});

  # Detect format
  my $renderer = $self->app->renderer;
  my $format = $self->format( $renderer->default_format, keys %$args );

  # Find target
  my $target = $args->{$format};
  unless( $target ) {
    return $self->rendered(204) unless $target = $args->{any};
  }

  # Dispatch
  ref $target eq 'CODE' ? $target->($self) : $self->render(%$target);

  return $self;
}
```


III. Also this patch fixing broken Mojolicious tests where it expects wrong data
[Here is testcase]((https://gist.github.com/KES777/1d44fa16ece82f7f71b33a70f933b764)) (short snippet from `t/mojolicous/exception_lite_app.t`)