### PR TITLE
Give a chance for custome handler to handle exception

### DIFF
--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -112,10 +112,10 @@ sub _development {
   my $mode    = $app->mode;
   my $options = {
     format   => $stash->{format} || $app->renderer->default_format,
-    handler  => undef,
     status   => $page eq 'exception' ? 500 : 404,
     template => "$page.$mode"
   };
+  $options->{handler} = undef if $stash->{ 'mojo.rendering' };
   my $bundled = 'mojo/' . ($mode eq 'development' ? 'debug' : $page);
   return $c if _fallbacks($c, $options, $page, $bundled);
   _fallbacks($c, {%$options, format => 'html'}, $page, $bundled);

--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -118,6 +118,9 @@ sub _development {
   $options->{handler} = undef if $stash->{ 'mojo.rendering' };
   my $bundled = 'mojo/' . ($mode eq 'development' ? 'debug' : $page);
   return $c if _fallbacks($c, $options, $page, $bundled);
+  if( !$stash->{ 'mojo.rendering' } ) {
+    return $c if _fallbacks($c, {%$options, handler => undef}, $page, $bundled)
+  }
   _fallbacks($c, {%$options, format => 'html'}, $page, $bundled);
   return $c;
 }

--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -212,7 +212,10 @@ sub _render_template {
   $c->app->log->error(qq{No handler for "$handler" available}) and return undef
     unless my $renderer = $self->handlers->{$handler};
 
+  # Do not use local. Value should be kept when exception occur
+  $c->stash->{ 'mojo.rendering' } =  1;
   $renderer->($self, $c, $output, $options);
+  delete $c->stash->{ 'mojo.rendering' };
   return 1 if defined $$output;
 }
 

--- a/t/mojolicious/exception_template_for_custom_handler.t
+++ b/t/mojolicious/exception_template_for_custom_handler.t
@@ -1,0 +1,26 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+
+use Mojolicious::Lite;
+
+app->renderer->add_handler(dead => sub { die 'Exception in handler' });
+app->renderer->add_handler(my   => sub {
+	${$_[2]} =  'my: ' .$_[1]->stash->{ exception };
+});
+
+get '/handler' => { handler => 'dead' } => sub{};
+get '/action'  => { handler => 'my'   } => sub{ die 'Exception in action' };
+
+my $t = Test::Mojo->new;
+
+$t->get_ok( '/action'  )->status_is(500)
+	->content_like(qr/^my: Exception in action/);
+$t->get_ok( '/handler' )->status_is(500)
+	->content_like(qr/^dead: Exception in handler/);
+
+done_testing();
+
+__DATA__
+@@ exception.html.ep
+dead: <%= stash->{ exception } %>

--- a/t/mojolicious/exception_template_for_custom_handler.t
+++ b/t/mojolicious/exception_template_for_custom_handler.t
@@ -4,18 +4,23 @@ use Test::More;
 
 use Mojolicious::Lite;
 
-app->renderer->add_handler(dead => sub { die 'Exception in handler' });
-app->renderer->add_handler(my   => sub {
-	${$_[2]} =  'my: ' .$_[1]->stash->{ exception };
+app->renderer->add_handler(dead    => sub { die 'Exception in handler' });
+app->renderer->add_handler(openapi => sub {
+	my( $r, $c, $output ) =  @_;
+
+	my $e =  $c->stash->{ exception };
+	chomp $e;
+	$$output =  qq!{ "error": "$e"}!;
 });
 
 get '/handler' => { handler => 'dead' } => sub{};
-get '/action'  => { handler => 'my'   } => sub{ die 'Exception in action' };
+get '/action'  => { handler => 'openapi', format => 'json' }
+	=> sub{ die 'Exception in action' };
 
 my $t = Test::Mojo->new;
 
 $t->get_ok( '/action'  )->status_is(500)
-	->content_like(qr/^my: Exception in action/);
+	->json_like( '/error' => qr/^Exception in action/ );
 $t->get_ok( '/handler' )->status_is(500)
 	->content_like(qr/^dead: Exception in handler/);
 


### PR DESCRIPTION
### Summary
If we register custom renderer handler we also should give it a change to process exceptions
[Currently](https://metacpan.org/source/SRI/Mojolicious-7.81/lib/Mojolicious/Plugin/DefaultHelpers.pm#L116) Mojolicious just flushes `handler` if exception occur

### Motivation
There are two cases where exception may occur:

  1. Exception may occur inside controler's action
  2. Exception may occur inside handler

For first case we should not clear `handler`. This will allow our handler to handle exception.
For second case we MUST clear `handler` because our handler did not done its job and we are required to fallback
