### PR TITLE
Can not pass varibles

### DIFF
--- a/t/mojolicious/command.t
+++ b/t/mojolicious/command.t
@@ -34,6 +34,9 @@ chdir $cwd;
 # Generating files
 is $command->rel_file('foo/bar.txt')->basename, 'bar.txt', 'right result';
 my $template = "@@ foo_bar\njust <%= 'works' %>!\n";
+$template .= "@@ pass_by_value\nvariable value <%= \$_[0] %>\n";
+$template .= "@@ pass_many\nmany values: <%= \@_ %>\n";
+$template .= "@@ pass_by_name\nvariable value <%= \$foo %>\n";
 open my $data, '<', \$template;
 no strict 'refs';
 *{"Mojolicious::Command::DATA"} = $data;
@@ -72,6 +75,16 @@ like $buffer, qr/\[exist\]/, 'right output';
 open my $xml, '<', $command->rel_file('123.xml');
 is join('', <$xml>), "seems\nto\nwork", 'right result';
 chdir $cwd;
+
+# Pass variables into template
+$buffer =  $command->render_data( 'pass_by_value', 'yada' );
+is $buffer, "variable value yada\n", 'pass variable by value';
+
+$buffer =  $command->render_data( 'pass_by_value', 'foo', 'bar' );
+is $buffer, "many values: foo bar\n", 'pass many variables by value';
+
+$buffer =  $command->render_data( 'pass_by_name', { foo => 'bar' } );
+is $buffer, "variable value bar\n", 'pass variable by name';
 
 # Quiet
 chdir $dir;


### PR DESCRIPTION
```
ok 1 - 'right application' isa 'Mojolicious'
ok 2 - right output
ok 3 - directory exists
ok 4 - right output
ok 5 - right result
ok 6 - right output
ok 7 - right result
ok 8 - right output
ok 9 - file is executable
ok 10 - right output
ok 11 - right output
ok 12 - right result
ok 13 - pass variable by value
not ok 14 - pass many variables by value
#   Failed test 'pass many variables by value'
#   at t/mojolicious/command.t line 84.
#          got: 'variable value foo
# '
#     expected: 'many values: foo bar
# '
not ok 15 - pass variable by name
#   Failed test 'pass variable by name'
#   at t/mojolicious/command.t line 87.
#          got: 'Global symbol "$foo" requires explicit package name (did you forget to declare "my $foo"?) at template pass_by_name from DATA section line 1, <$xml> line 3.
# 1: variable value <%= $foo %>
# '
#     expected: 'variable value bar
# '
ok 16 - no output
ok 17 - right error
1..17
# Looks like you failed 2 tests of 17.
```