### PR TITLE
Improve link_to helper

### DIFF
--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -116,8 +116,9 @@ sub _link_to {
 
   # Captures
   push @url, shift if ref $_[0] eq 'HASH';
+  my $query, shift if ref $_[0] eq 'ARRAY';
 
-  return _tag('a', href => $c->url_for(@url), @_);
+  return _tag('a', href => $c->url_for(@url)->query( $query // [] ), @_);
 }
 
 sub _option {


### PR DESCRIPTION
### Summary
Improve link_to helper

### Motivation
This changes are useful because we don't have to change the call
from link_to to link_to + url_for

    link_to Home => 'index' => {format => 'txt'} => [ query => 'value' ]

Instead of:

    link_to Home => url_for( 'index' => {format => 'txt'} )
        ->query([ query => 'value' ]);

