### PR TITLE
Improve link_to helper

### DIFF
--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -116,9 +116,15 @@ sub _link_to {
 
   # Captures
   push @url, shift if ref $_[0] eq 'HASH';
-  my $query, shift if ref $_[0] eq 'ARRAY';
 
-  return _tag('a', href => $c->url_for(@url)->query( $query // [] ), @_);
+  # Query
+  my $url = $c->url_for(@url);
+  if( ref $_[0] ) {
+    my $query =  shift;
+    ref $query eq 'SCALAR'? $url->query( @$$query ) : $url->query( $query );
+  }
+
+  return _tag('a', href => $url, @_);
 }
 
 sub _option {

--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -116,8 +116,9 @@ sub _link_to {
 
   # Captures
   push @url, shift if ref $_[0] eq 'HASH';
+  my $query, shift if ref $_[0] eq 'ARRAY';
 
-  return _tag('a', href => $c->url_for(@url), @_);
+  return _tag('a', href => $c->url_for(@url)->query( $query // [] ), @_);
 }
 
 sub _option {


### PR DESCRIPTION
### Summary
Improve link_to helper

### Motivation
This changes are useful because we don't have to change the call
from link_to to link_to + url_for

    link_to Home => 'index' => {format => 'txt'} => [ query => 'value' ]

Instead of:

    link_to Home => url_for( 'index' => {format => 'txt'} )
        ->query([ query => 'value' ]);

