### PR TITLE
Application command should be able to render template in loop

### DIFF
--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -77,7 +77,7 @@ sub render {
   my $options = {
     encoding => $self->encoding,
     handler  => $stash->{handler},
-    template => delete $stash->{template},
+    template => $stash->{template},
     variant  => $stash->{variant}
   };
   my $inline = $options->{inline} = delete $stash->{inline};

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -177,6 +177,12 @@ is $t->app->plugins->emit_chain(custom_chain => 4), 8, 'hook has been emitted';
 # MojoliciousTest::Command::test_command (with abbreviation)
 is $t->app->start(qw(test_command --to)), 'works too!', 'right result';
 
+# Render application template in loop from command
+is $t->app->start(qw(render_template)), "invoice\ninvoice\n",
+  'rendered twice';
+is $t->app->start(qw(render_template --stash)), "invoice\ninvoice\n",
+  'rendered twice';
+
 # Plugin::Test::SomePlugin2::register (security violation)
 $t->get_ok('/plugin-test-some_plugin2/register')->status_isnt(500)
   ->status_is(404)->header_is(Server => 'Mojolicious (Perl)')

--- a/t/mojolicious/lib/MojoliciousTest/Command/render_template.pm
+++ b/t/mojolicious/lib/MojoliciousTest/Command/render_template.pm
@@ -1,0 +1,20 @@
+package MojoliciousTest::Command::render_template;
+use Mojo::Base 'Mojolicious::Command';
+
+use Mojo::Util 'getopt';
+
+sub run {
+  my ($self, @args) = @_;
+  getopt \@args, 'stash' => \my $stash;
+
+  my $c =  $self->app->build_controller;
+  if( $stash ) {
+	$c->stash(template => 'invoice');
+  	return $c->render_to_string().$c->render_to_string();
+  }
+  else {
+  	return $c->render_to_string('invoice').$c->render_to_string('invoice');
+  }
+}
+
+1;

--- a/t/mojolicious/templates/invoice.html.ep
+++ b/t/mojolicious/templates/invoice.html.ep
@@ -1,0 +1,1 @@
+invoice


### PR DESCRIPTION
### Summary
An application allow users to download or view invoice by clicking a button.
But also we want the command which will loop users and send invoices

### Motivation
We have two ways to render templates:

  - First:
```    
    $c->stash( template => 'invoice' )
    while( my $user =  $users->next ) {
        $c->render_to_string( user => $user );
    }
```

  - Second:
```
    while( my $user =  $users->next ) {
        $c->render_to_string( 'invoice', user => $user );
    }
```

Without [this](https://github.com/KES777/mojo/compare/master...KES777:render_template_in_loop_by_command?expand=1#diff-ccf996555125c90064b288a0e4c139c5R80) change first case does now work. It renders only once.


### References
None
