### PR TITLE
Remove use of Mojo::Home

### DIFF
--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -5,7 +5,6 @@ use Mojo::Cache;
 use Mojo::DynamicMethods;
 use Mojo::File 'path';
 use Mojo::JSON 'encode_json';
-use Mojo::Home;
 use Mojo::Loader 'data_section';
 use Mojo::Util qw(decamelize encode gzip md5_sum monkey_patch);
 
@@ -18,8 +17,7 @@ has [qw(handlers helpers)] => sub { {} };
 has paths => sub { [] };
 
 # Bundled templates
-my $TEMPLATES = Mojo::Home->new->mojo_lib_dir->child('Mojolicious', 'resources',
-  'templates');
+my $TEMPLATES = path(__FILE__)->sibling('resources', 'templates');
 
 sub DESTROY { Mojo::Util::_teardown($_) for @{shift->{namespaces}} }
 

--- a/lib/Mojolicious/Static.pm
+++ b/lib/Mojolicious/Static.pm
@@ -5,13 +5,11 @@ use Mojo::Asset::File;
 use Mojo::Asset::Memory;
 use Mojo::Date;
 use Mojo::File 'path';
-use Mojo::Home;
 use Mojo::Loader qw(data_section file_is_binary);
 use Mojo::Util qw(encode md5_sum trim);
 
 # Bundled files
-my $PUBLIC = Mojo::Home->new(Mojo::Home->new->mojo_lib_dir)
-  ->child('Mojolicious', 'resources', 'public');
+my $PUBLIC = path(__FILE__)->sibling('resources', 'public');
 my %EXTRA = $PUBLIC->list_tree->map(
   sub { join('/', @{$_->to_rel($PUBLIC)}), $_->realpath->to_string })->each;
 


### PR DESCRIPTION
### Summary
In both Mojolicious::Renderer and Mojolicious::Static, Mojo::File is already
being used. Rather than using Mojo::Home, we can use path(\_\_FILE\_\_) to shorten
the detection of the resources paths. This more closely mimics what is done
in Minion

### Motivation
Code simplification

### References
[Here](https://github.com/mojolicious/minion/blob/master/lib/Mojolicious/Plugin/Minion/Admin.pm#L14) is how Minion get path to its resources